### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/xinw0085/6319b3dd-1d92-49de-8a77-03f038a38b3a/00d941b4-3c7e-4978-868b-728e988300e8/_apis/work/boardbadge/bb3598d2-edd6-4461-94b1-d953d2d34e6c)](https://dev.azure.com/xinw0085/6319b3dd-1d92-49de-8a77-03f038a38b3a/_boards/board/t/00d941b4-3c7e-4978-868b-728e988300e8/Microsoft.RequirementCategory)
 Calculator.js: a node.js Demonstration Project
 ==============================================
 An example node.js project, including tests with mocha, that behaves like


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#173](https://dev.azure.com/xinw0085/6319b3dd-1d92-49de-8a77-03f038a38b3a/_workitems/edit/173). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.